### PR TITLE
add null check and fallback to document.getSelection to handle firefo…

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function clipboardCopy (text) {
   win.document.body.appendChild(span)
 
   var selection = win.getSelection()
+  if (selection === null) selection = document.getSelection()
   var range = win.document.createRange()
 
   var success = false


### PR DESCRIPTION
On firefox 45.7.0 `win.contentWindow.getSelection()` returns call causing two issue in clipboard-copy:

1. The current selection is not updated and the intended text is not copied to the clipboard
2. The call to `selection.removeAllRanges()` outside of the `try-catch` block throws a `TypeError` and the `iframe` is never removed from the document, causing a spooky contentless-border to appear!

The fix for this seems to be a null check on the return of `win.contentWindow.getSelection` and falling back to `document.getSelection` if the check check succeeds.

I checked if replacing `win.contentWindow.getSelection` with `document.getSelection` succeeds in all cases, but it fails to copy the desired contents in at least chrome 56.0.2924.87.

This fix passes all tests, adds a line, and bumps the byte count by approximately 59 bytes.
