### PR TITLE
Use the Async Clipboard API when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ triggered in direct response to a user gesture like a `'click'` or a `'keypress'
 
 ## comparison to alternatives
 
-- **`clipboard-copy` (this package): 542 bytes**
-- [`clipboard-js`](https://www.npmjs.com/package/clipboard-js): 1.83 kB
-- [`clipboard`](https://www.npmjs.com/package/clipboard): 3.19 kB
+- **`clipboard-copy` (this package): 598 bytes**
+- [`clipboard-js`](https://www.npmjs.com/package/clipboard-js): 1.91 kB
+- [`clipboard`](https://www.npmjs.com/package/clipboard): 10.66 kB
 
 ## testing
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-declare function clipboardCopy (text: string): boolean
+declare function clipboardCopy (text: string): Promise
 export = clipboardCopy

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-declare function clipboardCopy (text: string): Promise
+declare function clipboardCopy (text: string): Promise<void>
 export = clipboardCopy

--- a/index.js
+++ b/index.js
@@ -21,14 +21,15 @@ function clipboardCopy (text) {
 
   // Add the <iframe> to the page
   document.body.appendChild(iframe)
+  var win = iframe.contentWindow
 
   // Add the <span> to the <iframe>
-  var win = iframe.contentWindow
   win.document.body.appendChild(span)
 
+  // Get a Selection object representing the range of text selected by the user
   var selection = win.getSelection()
 
-  // Firefox fails to get a selection from <iframe> window, so fallback
+  // Fallback for Firefox which fails to get a selection from an <iframe>
   if (!selection) {
     win = window
     selection = win.getSelection()

--- a/index.js
+++ b/index.js
@@ -50,4 +50,6 @@ function clipboardCopy (text) {
   document.body.removeChild(iframe)
 
   return success
+    ? Promise.resolve()
+    : Promise.reject() // eslint-disable-line prefer-promise-reject-errors
 }

--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ function clipboardCopy (text) {
   win.document.body.removeChild(span)
   document.body.removeChild(iframe)
 
+  // The Async Clipboard API returns a promise that may reject with `undefined` so we
+  // match that here for consistency.
   return success
     ? Promise.resolve()
     : Promise.reject() // eslint-disable-line prefer-promise-reject-errors

--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 module.exports = clipboardCopy
 
 function clipboardCopy (text) {
+  // Use the Async Clipboard API when available
+  if (navigator.clipboard) {
+    return navigator.clipboard.writeText(text)
+  }
+
+  // ...Otherwise, use document.execCommand() fallback
+
   // Put the text to copy into a <span>
   var span = document.createElement('span')
   span.textContent = text


### PR DESCRIPTION
This also introduces a breaking change, i.e. returns a Promise instead of a boolean since the new Clipboard API is async.

More info: https://developers.google.com/web/updates/2018/03/clipboardapi