### PR TITLE
Reject with NotAllowedError when copying fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,6 @@ function clipboardCopy (text) {
   win.document.body.removeChild(span)
   document.body.removeChild(iframe)
 
-  // The Async Clipboard API returns a promise that may reject with `undefined` so we
-  // match that here for consistency.
   return success
     ? Promise.resolve()
     : Promise.reject(new DOMException('The request is not allowed', 'NotAllowedError'))

--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
+/* global DOMException */
+
 module.exports = clipboardCopy
 
 function clipboardCopy (text) {
   // Use the Async Clipboard API when available
   if (navigator.clipboard) {
-    return navigator.clipboard.writeText(text)
+    return navigator.clipboard.writeText(text).catch(function (err) {
+      throw (err !== undefined ? err : new DOMException('The request is not allowed', 'NotAllowedError'))
+    })
   }
 
   // ...Otherwise, use document.execCommand() fallback
@@ -54,5 +58,5 @@ function clipboardCopy (text) {
   // match that here for consistency.
   return success
     ? Promise.resolve()
-    : Promise.reject() // eslint-disable-line prefer-promise-reject-errors
+    : Promise.reject(new DOMException('The request is not allowed', 'NotAllowedError'))
 }


### PR DESCRIPTION
We should probably hold off and see what happens with w3c/clipboard-apis#82 first.

I really think that rejecting with `undefined` is going to cause hard to track down problems for people, e.g. "Cannot read property stack of undefined", "(node:54056) UnhandledPromiseRejectionWarning: undefined", and I personally don't see a problem with defining a better API ourselves.