### PR TITLE
Fixed copy 

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ function clipboardCopy (text) {
   // Get a Selection object representing the range of text selected by the user
   var selection = win.getSelection()
 
-  // Fallback for Firefox which fails to get a selection from an <iframe>
-  if (!selection) {
+  // Fallback when iframe's window can not access functions <iframe>
+  if (!win.clipboardCopy) {
     win = window
     selection = win.getSelection()
     document.body.appendChild(span)


### PR DESCRIPTION
Fixed #30
The latest version of chrome returns a window with empty default functions from inside the iframe. This caused the fallback to not trigger.

Tested on the latest version of chrome(Version 72.0.3626.109 (Official Build) (64-bit)) and Firefox(65.0 (64-bit)).