### PR TITLE
fallback to document.execCommand() if Clipboard API fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function copyViaClipboardApi (text) {
   // context (i.e. HTTPS)
   return navigator.clipboard
     ? navigator.clipboard.writeText(text)
-    : Promise.reject()
+    : Promise.reject() // eslint-disable-line prefer-promise-reject-errors
 }
 
 function clipboardCopy (text) {


### PR DESCRIPTION
if Clipboard API fails, `document.execCommand()` may still work - I reproduce this in Android webview in Yandex Search APP https://play.google.com/store/apps/details?id=ru.yandex.searchplugin&hl=ru