### PR TITLE
make span copyable in app browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ function clipboardCopy (text) {
 
   // Preserve consecutive spaces and newlines
   span.style.whiteSpace = 'pre'
-  
   span.style.webkitUserSelect = 'auto'
   span.style.userSelect = 'all'
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ function clipboardCopy (text) {
 
   // Preserve consecutive spaces and newlines
   span.style.whiteSpace = 'pre'
+  
+  span.style.webkitUserSelect = 'auto'
+  span.style.userSelect = 'all'
 
   // Add the <span> to the page
   document.body.appendChild(span)


### PR DESCRIPTION
I experienced problems in a cordova app. Found a solution https://stackoverflow.com/questions/35281283/safari-getselection-not-working and implemented it.